### PR TITLE
Remove `module_to_distro.json` and related code

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,7 +113,7 @@ profiling = [
 
 # Optional dependency needed when use_gunicorn is set to true
 gunicorn = [
-  "gunicorn~=23.0"
+  "gunicorn~=23.0",
 ]
 
 
@@ -234,9 +234,6 @@ nat = "nat.cli.main:run_cli"
 [tool.setuptools]
 include-package-data = true
 
-[tool.setuptools.package-data]
-nat = ["meta/module_to_distro.json"]
-
 # List any markers that users would reasonably want to filter by.
 # These show up when querying `pytest --markers`
 [tool.pytest.ini_options]
@@ -253,7 +250,7 @@ filterwarnings = [
   # trigger the warnings. In Python 3.12 this triggers a SyntaxWarning, in Python 3.11 it triggers a DeprecationWarning
   # which unfortunately pytest is unable to filter.
   # Remove once https://github.com/qdrant/qdrant-client/issues/983 is resolved.
-  "ignore:^invalid escape sequence:SyntaxWarning"
+  "ignore:^invalid escape sequence:SyntaxWarning",
 ]
 testpaths = ["tests", "examples/*/tests", "packages/*/tests"]
 asyncio_mode = "auto"

--- a/src/nat/data_models/discovery_metadata.py
+++ b/src/nat/data_models/discovery_metadata.py
@@ -103,21 +103,6 @@ class DiscoveryMetadata(BaseModel):
 
     @staticmethod
     @lru_cache
-    def get_distribution_name_from_private_data(root_package: str) -> str | None:
-        # Locate distibution mapping stored in the packages private data
-        module = __import__(root_package)
-        for path in module.__path__:
-            package_dir = Path(path).resolve()
-            distinfo_path = package_dir / "meta" / "module_to_distro.json"
-
-            if distinfo_path.exists():
-                with distinfo_path.open("r") as f:
-                    data = json.load(f)
-                    return data.get(root_package, None)
-        return None
-
-    @staticmethod
-    @lru_cache
     def get_distribution_name_from_module(module: ModuleType | None) -> str:
         """Get the distribution name from the config type using the mapping of module names to distro names.
 
@@ -164,18 +149,6 @@ class DiscoveryMetadata(BaseModel):
         """
         module = inspect.getmodule(config_type)
         return DiscoveryMetadata.get_distribution_name_from_module(module)
-
-    @staticmethod
-    @lru_cache
-    def get_distribution_name(root_package: str) -> str:
-        """
-        The NAT library packages use a distro name 'nvidia-nat[]' and
-        root package name 'nat'. They provide mapping in a metadata file
-        for optimized installation.
-        """
-
-        distro_name = DiscoveryMetadata.get_distribution_name_from_private_data(root_package)
-        return distro_name if distro_name else root_package
 
     @staticmethod
     def from_config_type(config_type: type["TypedBaseModelT"],

--- a/src/nat/meta/module_to_distro.json
+++ b/src/nat/meta/module_to_distro.json
@@ -1,4 +1,0 @@
-{
-    "aiq": "nvidia-nat",
-    "nat": "nvidia-nat"
-}

--- a/tests/nat/observability/exporter/test_file_exporter.py
+++ b/tests/nat/observability/exporter/test_file_exporter.py
@@ -339,7 +339,9 @@ class TestFileExporterEdgeCases:
 
     def test_processor_type_checking(self, mock_context_state):
         """Test that the processor is of the correct type."""
-        exporter = FileExporter(context_state=mock_context_state, output_path="./.tmp/test.jsonl", project="test_project")
+        exporter = FileExporter(context_state=mock_context_state,
+                                output_path="./.tmp/test.jsonl",
+                                project="test_project")
 
         assert isinstance(exporter._processor, IntermediateStepSerializer)
         assert hasattr(exporter._processor, 'process')


### PR DESCRIPTION
## Description
* Remove unused `get_distribution_name` and `get_distribution_name_from_private_data` methods from the `nat.data_models.discovery_metadata` module.
* Includes unrelated drive-by formatting fix

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
