### PR TITLE
Fix ADK demo weather and time city support

### DIFF
--- a/examples/frameworks/adk_demo/src/nat_adk_demo/nat_time_tool.py
+++ b/examples/frameworks/adk_demo/src/nat_adk_demo/nat_time_tool.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 
 import datetime
-import logging
 from collections.abc import AsyncIterator
 from zoneinfo import ZoneInfo
 
@@ -24,7 +23,29 @@ from nat.builder.function_info import FunctionInfo
 from nat.cli.register_workflow import register_function
 from nat.data_models.function import FunctionBaseConfig
 
-logger = logging.getLogger(__name__)
+CITY_TIMEZONES = {
+    "london": ("London", "Europe/London"),
+    "new york": ("New York", "America/New_York"),
+    "tokyo": ("Tokyo", "Asia/Tokyo"),
+}
+
+CITY_ALIASES = {
+    "london, england": "london",
+    "london, uk": "london",
+    "london, united kingdom": "london",
+    "new york city": "new york",
+    "new york, ny": "new york",
+    "new york, usa": "new york",
+    "new york, united states": "new york",
+    "nyc": "new york",
+    "tokyo, japan": "tokyo",
+}
+
+
+def _normalize_city(city: str) -> str:
+    """Normalize city names and common qualified variants."""
+    normalized_city = " ".join(city.strip().casefold().split())
+    return CITY_ALIASES.get(normalized_city, normalized_city)
 
 
 class TimeMCPToolConfig(FunctionBaseConfig, name="get_city_time_tool"):
@@ -52,10 +73,13 @@ async def get_city_time(_config: TimeMCPToolConfig, _builder: Builder) -> AsyncI
             str: The current time in the specified city or an error message if the city is not recognized.
         """
 
-        if city.strip().casefold() not in {"new york", "new york city", "nyc"}:
+        city_timezone = CITY_TIMEZONES.get(_normalize_city(city))
+        if city_timezone is None:
             return f"Sorry, I don't have timezone information for {city}."
 
-        now = datetime.datetime.now(ZoneInfo("America/New_York"))
-        return f"The current time in {city} is {now.strftime('%Y-%m-%d %H:%M:%S %Z%z')}"
+        canonical_city, timezone_name = city_timezone
+        now = datetime.datetime.now(ZoneInfo(timezone_name))
+        local_time = now.strftime("%Y-%m-%d %H:%M:%S %Z%z")
+        return f"The current time in {canonical_city} is {local_time}"
 
     yield FunctionInfo.from_fn(_get_city_time, description=_get_city_time.__doc__)

--- a/examples/frameworks/adk_demo/src/nat_adk_demo/weather_update_tool.py
+++ b/examples/frameworks/adk_demo/src/nat_adk_demo/weather_update_tool.py
@@ -23,6 +23,35 @@ from nat.cli.register_workflow import register_function
 from nat.data_models.function import FunctionBaseConfig
 
 
+WEATHER_BY_CITY = {
+    "london": ("London",
+               "The weather in London is partly cloudy with a temperature of 18 degrees Celsius "
+               "(64 degrees Fahrenheit)."),
+    "new york": ("New York",
+                 "The weather in New York is sunny with a temperature of 25 degrees Celsius (77 degrees Fahrenheit)."),
+    "tokyo": ("Tokyo",
+              "The weather in Tokyo is clear with a temperature of 22 degrees Celsius (72 degrees Fahrenheit)."),
+}
+
+CITY_ALIASES = {
+    "london, england": "london",
+    "london, uk": "london",
+    "london, united kingdom": "london",
+    "new york city": "new york",
+    "new york, ny": "new york",
+    "new york, usa": "new york",
+    "new york, united states": "new york",
+    "nyc": "new york",
+    "tokyo, japan": "tokyo",
+}
+
+
+def _normalize_city(city: str) -> str:
+    """Normalize city names and common qualified variants."""
+    normalized_city = " ".join(city.strip().casefold().split())
+    return CITY_ALIASES.get(normalized_city, normalized_city)
+
+
 class WeatherToolConfig(FunctionBaseConfig, name="weather_update"):
     pass
 
@@ -40,8 +69,11 @@ async def weather_update(_config: WeatherToolConfig, _builder: Builder) -> Async
         Returns:
             str: The current weather for the specified city.
         """
-        if city.lower() == "new york":
-            return "The weather in New York is sunny with a temperature of 25 degrees Celsius (77 degrees Fahrenheit)."
+        city_weather = WEATHER_BY_CITY.get(_normalize_city(city))
+        if city_weather is not None:
+            _, weather = city_weather
+            return weather
+
         return f"Weather information for '{city}' is not available."
 
     yield FunctionInfo.from_fn(_weather_update, description=_weather_update.__doc__)

--- a/examples/frameworks/adk_demo/tests/test_adk_demo_tools.py
+++ b/examples/frameworks/adk_demo/tests/test_adk_demo_tools.py
@@ -35,10 +35,10 @@ BUILDER = cast(Builder, None)
     ],
 )
 async def test_weather_update_supports_demo_cities(city: str, expected_city: str):
-    tool_info = await anext(weather_update(WeatherToolConfig(), BUILDER))
-    assert tool_info.single_fn is not None
+    async with weather_update(WeatherToolConfig(), BUILDER) as tool_info:
+        assert tool_info.single_fn is not None
 
-    result = await tool_info.single_fn(city)
+        result = await tool_info.single_fn(city)
 
     assert expected_city in result
     assert "not available" not in result
@@ -55,10 +55,10 @@ async def test_weather_update_supports_demo_cities(city: str, expected_city: str
 async def test_get_city_time_supports_demo_cities(city: str,
                                                  expected_city: str,
                                                  expected_timezone: tuple[str, ...]):
-    tool_info = await anext(get_city_time(TimeMCPToolConfig(), BUILDER))
-    assert tool_info.single_fn is not None
+    async with get_city_time(TimeMCPToolConfig(), BUILDER) as tool_info:
+        assert tool_info.single_fn is not None
 
-    result = await tool_info.single_fn(city)
+        result = await tool_info.single_fn(city)
 
     assert f"The current time in {expected_city}" in result
     assert any(timezone in result for timezone in expected_timezone)

--- a/examples/frameworks/adk_demo/tests/test_adk_demo_tools.py
+++ b/examples/frameworks/adk_demo/tests/test_adk_demo_tools.py
@@ -1,0 +1,65 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import cast
+
+import pytest
+
+from nat.builder.builder import Builder
+from nat_adk_demo.nat_time_tool import TimeMCPToolConfig
+from nat_adk_demo.nat_time_tool import get_city_time
+from nat_adk_demo.weather_update_tool import WeatherToolConfig
+from nat_adk_demo.weather_update_tool import weather_update
+
+BUILDER = cast(Builder, None)
+
+
+@pytest.mark.parametrize(
+    ("city", "expected_city"),
+    [
+        ("London", "London"),
+        ("Tokyo, Japan", "Tokyo"),
+        ("New York", "New York"),
+    ],
+)
+async def test_weather_update_supports_demo_cities(city: str, expected_city: str):
+    tool_info = await anext(weather_update(WeatherToolConfig(), BUILDER))
+    assert tool_info.single_fn is not None
+
+    result = await tool_info.single_fn(city)
+
+    assert expected_city in result
+    assert "not available" not in result
+
+
+@pytest.mark.parametrize(
+    ("city", "expected_city", "expected_timezone"),
+    [
+        ("London", "London", ("GMT", "BST")),
+        ("Tokyo, Japan", "Tokyo", ("JST",)),
+        ("New York", "New York", ("EST", "EDT")),
+    ],
+)
+async def test_get_city_time_supports_demo_cities(city: str,
+                                                 expected_city: str,
+                                                 expected_timezone: tuple[str, ...]):
+    tool_info = await anext(get_city_time(TimeMCPToolConfig(), BUILDER))
+    assert tool_info.single_fn is not None
+
+    result = await tool_info.single_fn(city)
+
+    assert f"The current time in {expected_city}" in result
+    assert any(timezone in result for timezone in expected_timezone)
+    assert "don't have timezone information" not in result


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description
<!-- Note: The pull request title will be included in the CHANGELOG. -->
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". All PRs should have an issue they close-->
Closes NAT-227

Updates the ADK demo weather and time tools so London and Tokyo return substantive demo responses instead of unsupported-city errors. The tools now normalize common city variants such as `Tokyo, Japan` and preserve the existing New York behavior.

Adds unit coverage for London, Tokyo, and New York tool responses without requiring live LLM calls.

Validation performed:
- `python3 -m py_compile examples/frameworks/adk_demo/src/nat_adk_demo/weather_update_tool.py examples/frameworks/adk_demo/src/nat_adk_demo/nat_time_tool.py examples/frameworks/adk_demo/tests/test_adk_demo_tools.py`
- Isolated direct behavior check with stubbed toolkit registration primitives for London, Tokyo, and New York

Not run in this cloud image:
- `uv run pytest examples/frameworks/adk_demo/tests/test_adk_demo_tools.py` (`uv` is not installed)
- `python3 -m pytest examples/frameworks/adk_demo/tests/test_adk_demo_tools.py` (`pytest` is not installed)

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [NAT-227](https://linear.app/nvidia/issue/NAT-227/nat-170develop-adk-demo-weathertime-tools-fail-for-london-and-tokyo)

<div><a href="https://cursor.com/agents/bc-fc480cac-dac2-4858-900f-c82e72c7d9dd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fc480cac-dac2-4858-900f-c82e72c7d9dd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

